### PR TITLE
Create preliminary Menu and Load Save screen

### DIFF
--- a/ScrabblersProject/.classpath
+++ b/ScrabblersProject/.classpath
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.USER_LIBRARY/JavaFX"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/ScrabblersProject/src/application/view/LoadSaves.fxml
+++ b/ScrabblersProject/src/application/view/LoadSaves.fxml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.text.Font?>
+
+
+<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1">
+   <children>
+      <Label alignment="CENTER" contentDisplay="CENTER" layoutX="185.0" layoutY="50.0" prefHeight="50.0" prefWidth="230.0" text="Select a save to load">
+         <font>
+            <Font size="24.0" />
+         </font>
+      </Label>
+      <Button layoutX="150.0" layoutY="110.0" mnemonicParsing="false" prefHeight="40.0" prefWidth="300.0" text="Save 1" textAlignment="CENTER" />
+      <Button layoutX="150.0" layoutY="160.0" mnemonicParsing="false" prefHeight="40.0" prefWidth="300.0" text="Save 2" textAlignment="CENTER" />
+      <Button layoutX="150.0" layoutY="210.0" mnemonicParsing="false" prefHeight="40.0" prefWidth="300.0" text="Save 3" textAlignment="CENTER" />
+      <Button layoutX="150.0" layoutY="310.0" mnemonicParsing="false" prefHeight="40.0" prefWidth="300.0" text="Save 5" textAlignment="CENTER" />
+      <Button layoutX="150.0" layoutY="260.0" mnemonicParsing="false" prefHeight="40.0" prefWidth="300.0" text="Save 4" textAlignment="CENTER" />
+   </children>
+</AnchorPane>

--- a/ScrabblersProject/src/application/view/MainDraft.fxml
+++ b/ScrabblersProject/src/application/view/MainDraft.fxml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.text.Font?>
+
+
+<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1">
+   <children>
+      <Button layoutX="200.0" layoutY="300.0" mnemonicParsing="false" prefHeight="50.0" prefWidth="200.0" text="Exit" textAlignment="CENTER" AnchorPane.bottomAnchor="50.0" AnchorPane.topAnchor="300.0">
+         <font>
+            <Font size="24.0" />
+         </font>
+      </Button>
+      <Button layoutX="200.0" layoutY="240.0" mnemonicParsing="false" prefHeight="50.0" prefWidth="200.0" text="Settings" textAlignment="CENTER">
+         <font>
+            <Font size="24.0" />
+         </font>
+      </Button>
+      <Button layoutX="200.0" layoutY="180.0" mnemonicParsing="false" prefHeight="50.0" prefWidth="200.0" text="Load Saves" textAlignment="CENTER">
+         <font>
+            <Font size="24.0" />
+         </font>
+      </Button>
+      <Button layoutX="200.0" layoutY="120.0" mnemonicParsing="false" prefHeight="50.0" prefWidth="200.0" text="Play" textAlignment="CENTER">
+         <font>
+            <Font size="24.0" />
+         </font>
+      </Button>
+      <Label alignment="CENTER" contentDisplay="CENTER" layoutX="200.0" layoutY="50.0" prefHeight="50.0" prefWidth="200.0" text="Scrabble">
+         <font>
+            <Font size="36.0" />
+         </font>
+      </Label>
+   </children>
+</AnchorPane>


### PR DESCRIPTION
### Summary
This pulll request creates skeleton for Menu and Load Save Screen, which involves
- [x] Create skeleton opening menu with Play, Load Save, Settings, and Exit buttons
- [x] Create skeleton load save screen with buttons to select previous saves

### Test Plan
Switch to menu-load-screens branch and verify if preliminary screens look good or require any other user interaction functions

### Notes
1. This does not have any functionality yet as they're just skeleton screens
2. For selecting saves, I believe we should:
     - Customize buttons to contain more information about the save (time spent, player color, etc.)
     - Instead of a menu button as drafted in proposal, the user should select a save then an additonal "Load Save" button that was previously greyed out should be clicked in order to load the selected save. I'll have to look into how to do this properly.